### PR TITLE
Add export_template function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,4 +17,5 @@ Suggests:
     testthat (>= 2.1.0)
 RoxygenNote: 6.1.1
 Imports: 
-    yaml
+    yaml,
+    utf8

--- a/R/export_template.R
+++ b/R/export_template.R
@@ -1,0 +1,26 @@
+#' Safely export templates to file.
+#'
+#' This is a simple wrapper function around [utf8::utf8_encode] and
+#' [base::writeLines], letting users write their template strings to file without
+#' having to worry about file encodings. For more details on why UTF-8
+#' encoding is necessary, check out
+#' [Yihui Xie's](https://yihui.org/en/2018/11/biggest-regret-knitr/) post on
+#' the subject.
+#'
+#' Note that this function is effectively the inverse of [import_pattern] --
+#' export_template(import_pattern("out.txt"), "out.txt") should always result
+#' in an unchanged file, and exceptions to this rule would be considered bugs.
+#'
+#' @param template The template string to be written out
+#' @param filename The path to write the template to, passed to [base::writeLines].
+#' Also accepts `stdout()` (and likely other similar functions) with a warning
+
+export_template <- function(template,
+                            filename,
+                            sep = "",
+                            filename.is.string = T) {
+  if (filename.is.string && !is.character(filename)) {
+    warning("Argument filename was passed something other than a string. You may get unexpected results.")
+  }
+  writeLines(utf8::as_utf8(template), filename, sep = sep, useBytes = T)
+}

--- a/tests/rmd/export_template_output.Rmd
+++ b/tests/rmd/export_template_output.Rmd
@@ -1,0 +1,6 @@
+## True Facts
+
+```{r}
+print("heddlr is great!")
+```
+

--- a/tests/testthat/test-export_template.R
+++ b/tests/testthat/test-export_template.R
@@ -1,0 +1,13 @@
+test_that("export_template doesn't fail silently", {
+  expect_error(export_template())
+  expect_error(export_template("text"))
+  expect_error(export_template(filename = "test.txt"))
+  expect_warning(export_template("test", stdout()))
+})
+
+test_that("export_template exports a template", {
+  pattern <- import_pattern("../rmd/sample_pattern.Rmd")
+  export_template(pattern, "../rmd/export_template_output.Rmd")
+  expect_equal(nchar(import_pattern("../rmd/export_template_output.Rmd")),
+               nchar(pattern))
+})


### PR DESCRIPTION
This commit introduces a dependency on the utf8 package (for the as_utf8 function), which could _likely_ be removed by shifting conversion to iconv. However, iconv seems to be... harder to reason around, so I'm comfortable with removing that dependency remaining a low-priority task.